### PR TITLE
canonical expver for FDB

### DIFF
--- a/definitions/grib2/local.78.def
+++ b/definitions/grib2/local.78.def
@@ -180,7 +180,7 @@ concept marsModel(unknown) {
       generatingProcessIdentifier = 151;}
 } : no_copy;
 
- constant marsExpver = 1;
+ constant marsExpver = 0001;
 
  alias mars.class = marsClass;
  alias mars.stream = marsStream;


### PR DESCRIPTION
FDB expects at retrieval time that expver comes in a canonical way (4 chars) instead of 1 integer. 
However at write time, it does not imposes checks nor transform, it will take grib encoding directly. 
This generates inconsistency between read and write. 