### PR TITLE
set number

### DIFF
--- a/definitions/grib2/local.78.def
+++ b/definitions/grib2/local.78.def
@@ -147,6 +147,11 @@ concept marsType(unknown) {
       derivedForecast = 4;}
 } : no_copy;
 
+if (marsType is "ememb")
+{
+   alias mars.number = perturbationNumber;
+}
+
 concept marsModel(unknown) {
     'COSMO-1E' = {
       generatingProcessIdentifier = 121;

--- a/definitions/grib2/local.78.def
+++ b/definitions/grib2/local.78.def
@@ -147,11 +147,6 @@ concept marsType(unknown) {
       derivedForecast = 4;}
 } : no_copy;
 
-if (marsType is "ememb")
-{
-   alias mars.number = perturbationNumber;
-}
-
 concept marsModel(unknown) {
     'COSMO-1E' = {
       generatingProcessIdentifier = 121;

--- a/definitions/mars/grib.enfo.ememb.def
+++ b/definitions/mars/grib.enfo.ememb.def
@@ -1,0 +1,1 @@
+alias mars.number = perturbationNumber;


### PR DESCRIPTION
Since we are defining new mars.types, some of the mappings (like mars.number) are not set, since they depend on the stream.type and they are set specifically for each of them. 

