### PR TITLE
Fix MARS key duplicates for records with levtype=heightAboveSea

### DIFF
--- a/definitions/grib2/local.78.def
+++ b/definitions/grib2/local.78.def
@@ -46,7 +46,7 @@ alias grib2LocalSectionNumber=localDefinitionNumber;
 
 if (centreForLocal == 215) {
  # class
- transient marsClass='od';
+ # transient marsClass='od';
 
 ## typeOfGeneratingProcess
 # COSMO-1E, COSMO-2E: 4 = Ensemble forecast

--- a/definitions/grib2/marsLevtypeConcept.def
+++ b/definitions/grib2/marsLevtypeConcept.def
@@ -13,13 +13,15 @@
 'pl'   = {typeOfFirstFixedSurface=100; typeOfSecondFixedSurface=255;}
 'pl'   = {typeOfFirstFixedSurface=100; typeOfSecondFixedSurface=100;}
 'sfc'  = {typeOfFirstFixedSurface=101; typeOfSecondFixedSurface=255;}
-'sfc'  = {typeOfFirstFixedSurface=102; typeOfSecondFixedSurface=255;}
+# heightAboveSea
+'ml'   = {typeOfFirstFixedSurface=102; typeOfSecondFixedSurface=255;}
 'sfc'  = {typeOfFirstFixedSurface=103; typeOfSecondFixedSurface=255;}
 'sfc'  = {typeOfFirstFixedSurface=103; typeOfSecondFixedSurface=103;}
 'ml'   = {typeOfFirstFixedSurface=105; typeOfSecondFixedSurface=255;}
 'ml'   = {typeOfFirstFixedSurface=105; typeOfSecondFixedSurface=105;}
-'sfc'  = {typeOfFirstFixedSurface=106; typeOfSecondFixedSurface=255;}
-'sfc'  = {typeOfFirstFixedSurface=106;typeOfSecondFixedSurface=106;}
+# depthBelowLand
+'ml'   = {typeOfFirstFixedSurface=106; typeOfSecondFixedSurface=255;}
+'ml'   = {typeOfFirstFixedSurface=106;typeOfSecondFixedSurface=106;}
 'pt'   = {typeOfFirstFixedSurface=107; typeOfSecondFixedSurface=255;}
 'pt'   = {typeOfFirstFixedSurface=107; typeOfSecondFixedSurface=107;}
 'pv'   = {typeOfFirstFixedSurface=109; typeOfSecondFixedSurface=255;}


### PR DESCRIPTION
typeOfLevel = (depthBelowLand, heightAboveSea) were interpreted as marsLevType = sfc, which meant there was no level (and theremore mars.levelist) defined. We require the level since we have multiple records with different scaledValueOfFirstFixedSurface etc. 
Changes marsLevType from sfc to ml for both (depthBelowLand, heightAboveSea).

This resolves the issue of duplicates for heightAboveSea , as records now have various level values.
This does not resolve the issue of duplicates for depthBelowLand, since the resulting level is 0 for multiple records (eg 0.01 rounds to 0, 0.05 rounds to 0 etc).