### PR TITLE
Fix duplicate class definition

### DIFF
--- a/definitions/grib2/local.78.def
+++ b/definitions/grib2/local.78.def
@@ -45,8 +45,6 @@ alias grib2LocalSectionNumber=localDefinitionNumber;
 }
 
 if (centreForLocal == 215) {
- # class
- transient marsClass='od';
 
 ## typeOfGeneratingProcess
 # COSMO-1E, COSMO-2E: 4 = Ensemble forecast


### PR DESCRIPTION
Defined already here: https://github.com/cosunae/eccodes-cosmo-resources/blob/2554b2bb00ffc4ee03249d043d91c1cebc78352e/definitions/grib2/local.78.def#L88C1-L90C25

Causes issues with FDB having double defintion